### PR TITLE
Remove ambition to add unipressed, add species constraint to mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,6 @@ The project is: _in progress_.
 ## Room for Improvement
 Room for improvement:
 - Better tests
-- Try incorporating unipressed
-- Improve overlap computations
 
 To do:
 - Support for more species

--- a/src/sponge/modules/ppi_retriever/ppi_retriever.py
+++ b/src/sponge/modules/ppi_retriever/ppi_retriever.py
@@ -108,7 +108,7 @@ class PPIRetriever:
             print ('Checking the conflicts in the UniProt database...')
             mapper = ProteinIDMapper(self.protein_url)
             uniprot_df = mapper.get_uniprot_mapping('Gene_Name', 'UniProtKB',
-                ids_to_check).set_index('from')
+                ids_to_check, taxonomy_id=9606).set_index('from')
             p_to_q = {p: q for q,p in zip(diff_df['queryName'],
                 diff_df['preferredName'])}
             # Keep the conflicts where there is a match or where one or both


### PR DESCRIPTION
After comparing performance, my own implementation of Uniprot mapping interface performs better than the unipressed once, so it will be kept.